### PR TITLE
api_object / __getattr__ - Use __dict__ to access members rather than at...

### DIFF
--- a/backslash/api_object.py
+++ b/backslash/api_object.py
@@ -16,8 +16,8 @@ class APIObject(object):
 
     def __getattr__(self, name):
         try:
-            return self._data[name]
-        except LookupError:
+            return self.__dict__['_data'][name]
+        except KeyError:
             raise AttributeError(name)
 
     def refresh(self):


### PR DESCRIPTION
...tributes. Prevents infinite recursion if _data isn't found in the instance
