### PR TITLE
Swallow git import exception

### DIFF
--- a/backslash/contrib/slash_plugin.py
+++ b/backslash/contrib/slash_plugin.py
@@ -13,7 +13,11 @@ import webbrowser
 import logbook
 import requests
 
-import git
+try:
+    import git
+except Exception as e: # pylint: disable=broad-except
+    pass
+
 import slash
 from sentinels import NOTHING
 from slash import config as slash_config


### PR DESCRIPTION
See the following issue which explains why we can't catch a specific exception type:

https://github.com/gitpython-developers/GitPython/issues/637