### PR TITLE
retry on 500s

### DIFF
--- a/backslash/api.py
+++ b/backslash/api.py
@@ -33,6 +33,7 @@ ObjectType = Union[Session, Test, Error, Warning, Comment, Suite, User]
 _RETRY_STATUS_CODES = frozenset([
     requests.codes.bad_gateway,
     requests.codes.gateway_timeout,
+    requests.codes.server_error,
 ])
 
 _TYPES_BY_TYPENAME = {


### PR DESCRIPTION
We noticed that occasionally we would see database deadlocks on `report_session_end` if a `send_keepalive` was also sent at roughly the same time. This results in the `report_session_end` post raising on a 500. 

This adds `server_error` or status code 500 to the backslash client's retry list.